### PR TITLE
Unmask tmpfs.mount for 1.1.2

### DIFF
--- a/dsglaser/cis_security/roles/cis_security/tasks/type-files/redhat-8-type.yml
+++ b/dsglaser/cis_security/roles/cis_security/tasks/type-files/redhat-8-type.yml
@@ -83,6 +83,12 @@
   # Create and configure the local-fs systemd service file
   - name: 1.1.[2-5] - Ensure /tmp is configured
     block:
+      # Cloud images often have tmpfs.mount masked. Unmask it so it can be enabled.
+      - name: Ensure tmpfs.mount is not masked
+        systemd:
+          name: tmpfs.mount
+          masked: no
+          
       # Create a file to hold the system specific local-fs service information
       #  be sure to set the selinux security context. Even if selinux is disabled,
       #  it's a good idea to make sure it is set on files


### PR DESCRIPTION
Running the role against an AWS CentOS 8 image fails when the handler tries to restart tmpfs.mount, because it is masked in that image.
Add a task to make sure it's unmasked as part of the 1.1.[2-5] tasks.